### PR TITLE
docs: document port range for off-shared

### DIFF
--- a/docs/ports-and-project-names.md
+++ b/docs/ports-and-project-names.md
@@ -33,7 +33,7 @@ You do not need to track the individual ports that you use here, please do that 
 
 | Port Range | Project Name | Repo | Events |
 |---|---|---|---|
-| 6379 (in staging) + 5700-57019 | off_shared | https://github.com/openfoodfacts/openfoodfacts-shared-services |  |
+| 6379, 27017, 5432 + 5700-57009 | off_shared | https://github.com/openfoodfacts/openfoodfacts-shared-services |  |
 
 | 80 | po_off | https://github.com/openfoodfacts/openfoodfacts-server | https://openfoodfacts.github.io/openfoodfacts-server/events/openfoodfacts-server.html |
 | 5500-5509 | robotoff | https://github.com/openfoodfacts/robotoff |  |

--- a/docs/ports-and-project-names.md
+++ b/docs/ports-and-project-names.md
@@ -33,7 +33,8 @@ You do not need to track the individual ports that you use here, please do that 
 
 | Port Range | Project Name | Repo | Events |
 |---|---|---|---|
-| 6379, 27017 | off_shared | https://github.com/openfoodfacts/openfoodfacts-shared-services |  |
+| 6379 (in staging) + 5700-57019 | off_shared | https://github.com/openfoodfacts/openfoodfacts-shared-services |  |
+
 | 80 | po_off | https://github.com/openfoodfacts/openfoodfacts-server | https://openfoodfacts.github.io/openfoodfacts-server/events/openfoodfacts-server.html |
 | 5500-5509 | robotoff | https://github.com/openfoodfacts/robotoff |  |
 | 5510-5519 | off-query | https://github.com/openfoodfacts/openfoodfacts-query | https://openfoodfacts.github.io/openfoodfacts-query/docs/events/openfoodfacts-query.html |

--- a/docs/ports-and-project-names.md
+++ b/docs/ports-and-project-names.md
@@ -33,7 +33,7 @@ You do not need to track the individual ports that you use here, please do that 
 
 | Port Range | Project Name | Repo | Events |
 |---|---|---|---|
-| 6379, 27017, 5432 + 5700-57009 | off_shared | https://github.com/openfoodfacts/openfoodfacts-shared-services |  |
+| 6379, 27017, 5432 + 5700-5709 | off_shared | https://github.com/openfoodfacts/openfoodfacts-shared-services |  |
 
 | 80 | po_off | https://github.com/openfoodfacts/openfoodfacts-server | https://openfoodfacts.github.io/openfoodfacts-server/events/openfoodfacts-server.html |
 | 5500-5509 | robotoff | https://github.com/openfoodfacts/robotoff |  |


### PR DESCRIPTION
going with https://github.com/openfoodfacts/openfoodfacts-shared-services/pull/24