### PR TITLE
docs: add open prices port range

### DIFF
--- a/docs/ports-and-project-names.md
+++ b/docs/ports-and-project-names.md
@@ -39,4 +39,5 @@ You do not need to track the individual ports that you use here, please do that 
 | 5510-5519 | off-query | https://github.com/openfoodfacts/openfoodfacts-query | https://openfoodfacts.github.io/openfoodfacts-query/docs/events/openfoodfacts-query.html |
 | 5520-5529 | recipe-estimator | https://github.com/openfoodfacts/recipe-estimator |  |
 | 5600-5609 | openfoodfacts-auth | https://github.com/openfoodfacts/openfoodfacts-auth | https://openfoodfacts.github.io/openfoodfacts-auth/docs/events/openfoodfacts-auth.html |
+| 8190-8200 | open-prices | https://github.com/openfoodfacts/open-prices | |
 | 8086, 8200-8210, 9090, 9114, 9115, 9200 | monitoring | https://github.com/openfoodfacts/openfoodfacts-monitoring | |


### PR DESCRIPTION
Currently, only 8190 is used by the nginx reverse proxy of Open Prices.