### PR TITLE
ci: permissions for semantic pr

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
ci: permissions for semantic pr

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privilege.  
- `contents: read` (safe baseline for repository reads)
- `pull-requests: read` (to read PR metadata/title)
