### PR TITLE
ci: permissions for top issues

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -1,4 +1,7 @@
 name: Top issues action.
+permissions:
+  contents: read
+  issues: write
 on:
   schedule:
   - cron:  '0 0 */1 * *'


### PR DESCRIPTION
ci: permissions for top issues

Add an explicit `permissions` block to `.github/workflows/top-issues.yml` so the `GITHUB_TOKEN` is scoped to only what this workflow needs.  

- `contents: read` (common minimal read access)
- `issues: write` (needed for labeling/updating issue dashboards)
